### PR TITLE
Fix BubbleMenu visible on page load before text selection

### DIFF
--- a/apps/web/src/lib/Editor.svelte
+++ b/apps/web/src/lib/Editor.svelte
@@ -278,6 +278,17 @@
             element: bubbleMenuElement,
             options: {
               offset: 10,
+              // Manually control visibility to prevent flash on initial load
+              onShow: () => {
+                if (bubbleMenuElement) {
+                  bubbleMenuElement.style.display = "flex";
+                }
+              },
+              onHide: () => {
+                if (bubbleMenuElement) {
+                  bubbleMenuElement.style.display = "none";
+                }
+              },
             },
             shouldShow: ({ editor: ed, view, state, from, to }) => {
               // Must be editable

--- a/apps/web/src/lib/components/BubbleMenuComponent.svelte
+++ b/apps/web/src/lib/components/BubbleMenuComponent.svelte
@@ -224,7 +224,8 @@
 
 <style>
   .bubble-menu {
-    display: flex;
+    /* Start hidden - controlled via onShow/onHide in Editor.svelte to prevent flash on initial load */
+    display: none;
     align-items: center;
     gap: 2px;
     padding: 4px;
@@ -235,8 +236,6 @@
       0 10px 15px -3px rgba(0, 0, 0, 0.1),
       0 4px 6px -2px rgba(0, 0, 0, 0.05);
     z-index: 50;
-    /* Start hidden - TipTap's BubbleMenu extension will show it */
-    visibility: hidden;
     position: fixed;
     /* Prevent text selection on toolbar */
     -webkit-user-select: none;


### PR DESCRIPTION
The BubbleMenu's CSS `visibility: hidden` was being overridden by
TipTap's BubbleMenuView.updatePosition() which unconditionally sets
`visibility: visible` as an inline style on scroll/resize events.
Use the same onShow/onHide display toggling pattern already used by
FloatingMenu to prevent the flash on initial load.

https://claude.ai/code/session_01HsCthMSCagASkNVa9oQoJF