### PR TITLE
Fix invisible list decorations in TipTap editor

### DIFF
--- a/apps/web/src/lib/Editor.svelte
+++ b/apps/web/src/lib/Editor.svelte
@@ -642,6 +642,15 @@
   :global(.editor-content ul),
   :global(.editor-content ol) {
     padding-left: 1.5em;
+    color: var(--foreground);
+  }
+
+  :global(.editor-content ul:not([data-type="taskList"])) {
+    list-style-type: disc;
+  }
+
+  :global(.editor-content ol) {
+    list-style-type: decimal;
   }
 
   :global(.editor-content li) {


### PR DESCRIPTION
Tailwind's preflight reset removes list-style-type from ul/ol globally.
Restore disc bullets and decimal numbers for lists inside .editor-content,
excluding task lists which intentionally use list-style: none. Also add
color: var(--foreground) so markers are visible in both light and dark modes.

https://claude.ai/code/session_01WirQCJoZ49r667iZeKUShu