### PR TITLE
fix: make focus mode header truly transparent by using absolute positioning

### DIFF
--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -1710,7 +1710,7 @@
   />
 
   <!-- Main Content Area -->
-  <main class="flex-1 flex flex-col overflow-hidden min-w-0">
+  <main class="flex-1 flex flex-col overflow-hidden min-w-0 relative">
     {#if currentEntry}
       <EditorHeader
         title={getEntryTitle(currentEntry)}

--- a/apps/web/src/views/editor/EditorHeader.svelte
+++ b/apps/web/src/views/editor/EditorHeader.svelte
@@ -88,8 +88,9 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <header
-  class="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border bg-background shrink-0
+  class="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border bg-background
     transition-opacity duration-300 ease-in-out
+    {shouldFade ? 'absolute inset-x-0 top-0 z-10' : 'shrink-0'}
     {shouldFade && !isHovered ? 'opacity-0' : 'opacity-100'}"
   onmouseenter={() => isHovered = true}
   onmouseleave={() => isHovered = false}


### PR DESCRIPTION
When both sidebars are closed in focus mode, the editor header faded to
opacity-0 but still occupied space in the flex layout, creating an
opaque dead zone where scrolling content couldn't reach. Switch to
absolute positioning when faded so content scrolls beneath the header.

https://claude.ai/code/session_018SEEqUevmzM5JDgYz6u42U