### PR TITLE
Redesign save indicator to be subtle icon-only button

### DIFF
--- a/apps/web/src/views/editor/EditorHeader.svelte
+++ b/apps/web/src/views/editor/EditorHeader.svelte
@@ -5,8 +5,7 @@
    * A pure presentational component that displays:
    * - Sidebar toggle buttons (only when sidebar is closed)
    * - Entry title and path (configurable via settings)
-   * - Unsaved indicator badge
-   * - Save button with keyboard shortcut tooltip
+   * - Save state indicator (icon-only: check=saved, dot=unsaved, spinner=saving)
    * - Command palette button with keyboard shortcut tooltip
    */
 
@@ -15,7 +14,8 @@
   import { getMobileState } from "$lib/hooks/useMobile.svelte";
   import SyncStatusIndicator from "$lib/SyncStatusIndicator.svelte";
   import {
-    Save,
+    Check,
+    Circle,
     PanelLeft,
     PanelRight,
     Menu,
@@ -199,38 +199,36 @@
         View only
       </span>
     {:else}
-      {#if isDirty && !isSaving}
-        <span
-          class="hidden sm:inline-flex px-2 py-1 text-xs font-medium rounded-md bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
-        >
-          Unsaved
-        </span>
-      {/if}
-
-      <!-- Save button with tooltip -->
+      <!-- Save indicator (icon-only) -->
       <Tooltip.Root>
         <Tooltip.Trigger>
           <Button
             onclick={onSave}
             disabled={!isDirty || isSaving}
-            variant={!isDirty && !isSaving ? "ghost" : "default"}
-            size="sm"
-            class="gap-1 md:gap-2 min-w-[80px]"
+            variant="ghost"
+            size="icon"
+            class="size-8"
+            aria-label={isSaving ? "Saving" : isDirty ? "Save" : "Saved"}
           >
             {#if isSaving}
-              <Loader2 class="size-4 animate-spin" />
-              <span class="hidden sm:inline">Saving...</span>
-            {:else if !isDirty}
-              <Save class="size-4 opacity-50" />
-              <span class="hidden sm:inline opacity-50">Saved</span>
+              <Loader2 class="size-4 animate-spin text-muted-foreground" />
+            {:else if isDirty}
+              <Circle class="size-3 fill-amber-500 text-amber-500 dark:fill-amber-400 dark:text-amber-400" />
             {:else}
-              <Save class="size-4" />
-              <span class="hidden sm:inline">Save</span>
+              <Check class="size-4 text-muted-foreground/50" />
             {/if}
           </Button>
         </Tooltip.Trigger>
         {#if !mobileState.isMobile}
-          <Tooltip.Content>Save ({modKey}S)</Tooltip.Content>
+          <Tooltip.Content>
+            {#if isSaving}
+              Saving...
+            {:else if isDirty}
+              Save ({modKey}S)
+            {:else}
+              Saved
+            {/if}
+          </Tooltip.Content>
         {/if}
       </Tooltip.Root>
     {/if}


### PR DESCRIPTION
Replace the prominent save button + "Unsaved" badge with a compact icon-only indicator that matches the size of other header actions:
- Saved: subtle muted checkmark
- Unsaved: small amber dot (clickable to save)
- Saving: muted spinner

https://claude.ai/code/session_014B5EKarHM9HJ8AqUVgppoN