### PR TITLE
Add image preview functionality for attachments

### DIFF
--- a/apps/web/src/lib/ImagePreviewDialog.svelte
+++ b/apps/web/src/lib/ImagePreviewDialog.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { X } from "@lucide/svelte";
+  import { Button } from "$lib/components/ui/button";
+
+  interface Props {
+    open: boolean;
+    imageUrl: string | null;
+    imageName: string;
+    onOpenChange: (open: boolean) => void;
+  }
+
+  let { open, imageUrl, imageName, onOpenChange }: Props = $props();
+</script>
+
+<Dialog.Root {open} {onOpenChange}>
+  <Dialog.Content
+    class="max-w-[90vw] max-h-[90vh] w-auto p-0 overflow-hidden bg-black/95 border-none"
+    showCloseButton={false}
+  >
+    <div class="relative flex items-center justify-center w-full h-full">
+      <!-- Header bar -->
+      <div class="absolute top-0 left-0 right-0 flex items-center justify-between px-4 py-2 bg-gradient-to-b from-black/60 to-transparent z-10">
+        <span class="text-sm text-white/80 truncate">{imageName}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          class="size-8 text-white/80 hover:text-white hover:bg-white/10"
+          onclick={() => onOpenChange(false)}
+          aria-label="Close preview"
+        >
+          <X class="size-5" />
+        </Button>
+      </div>
+
+      <!-- Image -->
+      {#if imageUrl}
+        <img
+          src={imageUrl}
+          alt={imageName}
+          class="max-w-[88vw] max-h-[85vh] object-contain select-none"
+          draggable="false"
+        />
+      {/if}
+    </div>
+  </Dialog.Content>
+</Dialog.Root>

--- a/apps/web/src/lib/RightSidebar.svelte
+++ b/apps/web/src/lib/RightSidebar.svelte
@@ -61,6 +61,7 @@
     titleError?: string | null;
     onTitleErrorClear?: () => void;
     onDeleteAttachment?: (attachmentPath: string) => void;
+    onPreviewAttachment?: (attachmentPath: string) => void;
     attachmentError?: string | null;
     onAttachmentErrorClear?: () => void;
     // History props
@@ -88,6 +89,7 @@
     titleError = null,
     onTitleErrorClear,
     onDeleteAttachment,
+    onPreviewAttachment,
     attachmentError = null,
     onAttachmentErrorClear,
     rustApi = null,
@@ -275,10 +277,31 @@
     return path.split("/").pop() ?? path;
   }
 
+  // Extract display name from an attachment value (may be a markdown link or plain path)
+  function getAttachmentDisplayName(attachment: string): string {
+    const parsed = parseLinkDisplay(attachment);
+    if (parsed) return parsed.title || getFilename(parsed.path);
+    return getFilename(attachment);
+  }
+
+  // Extract the actual file path from an attachment value (may be a markdown link or plain path)
+  function getAttachmentPath(attachment: string): string {
+    const parsed = parseLinkDisplay(attachment);
+    if (parsed) return parsed.path;
+    return attachment;
+  }
+
+  const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'];
+
+  function isImageAttachment(filename: string): boolean {
+    const ext = filename.split('.').pop()?.toLowerCase() || '';
+    return IMAGE_EXTS.includes(ext);
+  }
+
   // Get file type icon based on extension
   function getFileIcon(filename: string): Component {
     const ext = filename.split('.').pop()?.toLowerCase() || '';
-    const imageExts = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'];
+    const imageExts = IMAGE_EXTS;
     const docExts = ['pdf', 'doc', 'docx', 'txt', 'md', 'rtf'];
     const spreadsheetExts = ['xls', 'xlsx', 'csv'];
     const archiveExts = ['zip', 'tar', 'gz', '7z', 'rar'];
@@ -357,6 +380,9 @@
     return dateKeys.includes(lowerKey) || /^\d{4}-\d{2}-\d{2}/.test(value);
   }
 
+  // Keys that have dedicated UI sections and should not appear in generic metadata
+  const DEDICATED_SECTION_KEYS = ["attachments"];
+
   // Get frontmatter entries sorted with common fields first
   function getSortedFrontmatter(
     frontmatter: Record<string, unknown>,
@@ -370,7 +396,9 @@
       "part_of",
       "contents",
     ];
-    const entries = Object.entries(frontmatter);
+    const entries = Object.entries(frontmatter).filter(
+      ([key]) => !DEDICATED_SECTION_KEYS.includes(key.toLowerCase()),
+    );
 
     return entries.sort(([a], [b]) => {
       const aIndex = priorityKeys.indexOf(a.toLowerCase());
@@ -872,11 +900,14 @@
         {#if getAttachments().length > 0}
           <div class="space-y-1 mb-2">
             {#each getAttachments() as attachment}
-              {@const Icon = getFileIcon(getFilename(attachment))}
+              {@const displayName = getAttachmentDisplayName(attachment)}
+              {@const attachPath = getAttachmentPath(attachment)}
+              {@const Icon = getFileIcon(displayName)}
+              {@const isImage = isImageAttachment(displayName)}
               <div
                 class="flex items-center justify-between gap-2 px-2 py-1.5 rounded-md bg-secondary/50 group cursor-grab active:cursor-grabbing"
                 role="listitem"
-                aria-label="Attachment: {getFilename(attachment)}, drag to move"
+                aria-label="Attachment: {displayName}, drag to move"
                 draggable="true"
                 ondragstart={(e) => {
                   if (e.dataTransfer && entry) {
@@ -886,15 +917,20 @@
                   }
                 }}
               >
-                <div class="flex items-center gap-2 min-w-0">
+                <button
+                  type="button"
+                  class="flex items-center gap-2 min-w-0 {isImage ? 'hover:text-primary cursor-pointer' : 'cursor-default'}"
+                  onclick={() => isImage && onPreviewAttachment?.(attachment)}
+                  disabled={!isImage}
+                >
                   <Icon class="size-3.5 shrink-0 text-muted-foreground" />
                   <span
-                    class="text-xs text-foreground truncate"
-                    title={attachment}
+                    class="text-xs text-foreground truncate {isImage ? 'hover:underline' : ''}"
+                    title={isImage ? `Preview ${displayName}` : attachPath}
                   >
-                    {getFilename(attachment)}
+                    {displayName}
                   </span>
-                </div>
+                </button>
                 <Button
                   variant="ghost"
                   size="icon"
@@ -912,11 +948,12 @@
         {/if}
 
         <FilePickerPopover
-          excludePaths={getAttachments()}
+          excludePaths={getAttachments().map(getAttachmentPath)}
           placeholder="Add attachment..."
-          onSelect={(file) => {
+          onSelect={async (file) => {
+            const link = await formatAsLink(file.path, file.name);
             const currentAttachments = getAttachments();
-            onPropertyChange?.("attachments", [...currentAttachments, file.path]);
+            onPropertyChange?.("attachments", [...currentAttachments, link]);
           }}
         >
           <Button


### PR DESCRIPTION
## Summary
This PR adds the ability to preview image attachments directly in the application. Users can now click on image attachments in the right sidebar to view them in a full-screen preview dialog. Attachments are now stored as markdown links with display names, improving readability and metadata preservation.

## Key Changes

- **Image Preview Dialog**: Added new `ImagePreviewDialog.svelte` component that displays images in a modal with a header showing the image name and a close button
- **Preview Functionality**: 
  - Added `onPreviewAttachment` callback to `RightSidebar.svelte` to handle preview requests
  - Implemented `handlePreviewAttachment` in `App.svelte` to fetch attachment data and display it
  - Added HEIC to JPEG conversion support for compatibility
- **Attachment Display Improvements**:
  - Attachments are now stored as markdown links: `[filename](/path)` instead of plain paths
  - Added helper functions to parse and extract display names and paths from attachment values
  - Image attachments are now clickable with hover effects to indicate interactivity
- **Metadata Handling**:
  - Added `DEDICATED_SECTION_KEYS` constant to exclude "attachments" from generic metadata display
  - Filtered attachments from frontmatter entries to prevent duplication in UI
- **File Type Detection**: 
  - Extracted `IMAGE_EXTS` constant for reusable image extension checking
  - Added `isImageAttachment()` function to determine if an attachment is previewable
- **Backend Integration**: Updated `command_handler.rs` to format attachments as markdown root-relative links when uploading

## Implementation Details

- Image preview URLs are properly managed with `URL.revokeObjectURL()` to prevent memory leaks
- The preview dialog uses a dark theme (`bg-black/95`) for better image visibility
- Attachment paths are correctly extracted from markdown link format for file operations
- HEIC files are automatically converted to JPEG for broader browser compatibility
- The attachment picker now excludes already-attached files by extracting paths from markdown links

https://claude.ai/code/session_01Y53oW2cduzjt8biqqv42Vc