### PR TITLE
Fix dropdown positioning on mobile for picker components

### DIFF
--- a/apps/web/src/lib/Editor.svelte
+++ b/apps/web/src/lib/Editor.svelte
@@ -289,6 +289,10 @@
             element: bubbleMenuElement,
             options: {
               offset: 10,
+              // Keep BubbleMenu within viewport bounds (especially important on mobile)
+              shift: {
+                padding: 8,
+              },
               // Manually control visibility to prevent flash on initial load
               onShow: () => {
                 if (bubbleMenuElement) {

--- a/apps/web/src/lib/components/BlockStylePicker.svelte
+++ b/apps/web/src/lib/components/BlockStylePicker.svelte
@@ -337,6 +337,11 @@
 
   /* Mobile adjustments */
   @media (max-width: 767px) {
+    .block-style-picker-wrapper {
+      /* Remove positioning context so dropdown centers relative to .bubble-menu instead of this button */
+      position: static;
+    }
+
     .toolbar-button {
       padding: 8px;
       min-width: 36px;

--- a/apps/web/src/lib/components/HighlightColorPicker.svelte
+++ b/apps/web/src/lib/components/HighlightColorPicker.svelte
@@ -293,6 +293,11 @@
 
   /* Mobile adjustments */
   @media (max-width: 767px) {
+    .highlight-picker-wrapper {
+      /* Remove positioning context so dropdown centers relative to .bubble-menu instead of this button */
+      position: static;
+    }
+
     .toolbar-button {
       padding: 8px;
       min-width: 36px;

--- a/apps/web/src/lib/components/MoreStylesPicker.svelte
+++ b/apps/web/src/lib/components/MoreStylesPicker.svelte
@@ -268,6 +268,11 @@
 
   /* Mobile adjustments */
   @media (max-width: 767px) {
+    .more-styles-wrapper {
+      /* Remove positioning context so dropdown centers relative to .bubble-menu instead of this button */
+      position: static;
+    }
+
     .toolbar-button {
       padding: 8px;
       min-width: 36px;


### PR DESCRIPTION
## Summary
Fixed dropdown positioning issues on mobile devices for the BlockStylePicker, HighlightColorPicker, and MoreStylesPicker components. The dropdowns now properly center relative to the bubble menu instead of being constrained by their parent button's positioning context.

## Key Changes
- **BlockStylePicker.svelte**: Set `.block-style-picker-wrapper` to `position: static` on mobile to remove positioning context
- **HighlightColorPicker.svelte**: Set `.highlight-picker-wrapper` to `position: static` on mobile to remove positioning context
- **MoreStylesPicker.svelte**: Set `.more-styles-wrapper` to `position: static` on mobile to remove positioning context
- **Editor.svelte**: Added `shift` option with 8px padding to the BubbleMenu floating UI configuration to keep it within viewport bounds on mobile

## Implementation Details
The changes address a common positioning issue where absolutely positioned dropdowns were being constrained by their parent element's positioning context. By setting the wrapper elements to `position: static` on mobile (max-width: 767px), the dropdowns can now properly center relative to the `.bubble-menu` container instead of the individual button elements.

Additionally, the BubbleMenu's floating UI configuration now includes a `shift` option with padding to ensure the menu stays within viewport bounds, which is especially important on smaller mobile screens where space is limited.

https://claude.ai/code/session_01SKdURj8X3yGDWYP7dXybir