### PR TITLE
Convert boolean strings to YAML booleans in workspace config

### DIFF
--- a/crates/diaryx_core/src/workspace/mod.rs
+++ b/crates/diaryx_core/src/workspace/mod.rs
@@ -704,14 +704,20 @@ impl<FS: AsyncFileSystem> Workspace<FS> {
     /// # Arguments
     /// * `root_index_path` - Path to the root index file
     /// * `field` - Field name to set (e.g., "link_format", "daily_entry_folder")
-    /// * `value` - Value to set (will be stored as a string)
+    /// * `value` - Value to set as a string; boolean strings ("true"/"false") are
+    ///   stored as YAML booleans so that `as_bool()` works when reading back.
     pub async fn set_workspace_config_field(
         &self,
         root_index_path: &Path,
         field: &str,
         value: &str,
     ) -> Result<()> {
-        self.set_frontmatter_property(root_index_path, field, Value::String(value.to_string()))
+        let yaml_value = match value {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::String(value.to_string()),
+        };
+        self.set_frontmatter_property(root_index_path, field, yaml_value)
             .await
     }
 


### PR DESCRIPTION
## Summary
Updated `set_workspace_config_field` to automatically convert string values "true" and "false" to YAML boolean types, enabling proper boolean parsing when reading configuration values back.

## Changes
- Modified `set_workspace_config_field` to detect boolean string values ("true"/"false") and convert them to YAML `Bool` values instead of storing them as strings
- Updated the method's documentation to clarify that boolean strings are stored as YAML booleans for compatibility with `as_bool()` when reading values back
- Non-boolean string values continue to be stored as YAML strings as before

## Implementation Details
The change adds a simple match statement that intercepts the input value before passing it to `set_frontmatter_property`, ensuring that boolean configuration values are properly typed in the YAML representation rather than being stored as string literals.

https://claude.ai/code/session_01LPKBzwFf3uxChYpMVuGFs7