### PR TITLE
fix: prevent deleted files from reappearing after cloud sync

### DIFF
--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -37,6 +37,8 @@
   import EditorContent from "./views/editor/EditorContent.svelte";
   import { Toaster } from "$lib/components/ui/sonner";
   import * as Tooltip from "$lib/components/ui/tooltip";
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { Button } from "$lib/components/ui/button";
   import { toast } from "svelte-sonner";
   // Note: Button, icons, and LoadingSpinner are now only used in extracted view components
 
@@ -145,6 +147,13 @@
 
   // Add workspace dialog
   let showAddWorkspace = $state(false);
+
+  // Delete confirmation dialog state
+  let showDeleteConfirm = $state(false);
+  let pendingDeletePath = $state<string | null>(null);
+  let pendingDeleteName = $derived(
+    pendingDeletePath?.split('/').pop()?.replace('.md', '') ?? ''
+  );
 
   // Welcome screen (shown when no workspaces exist)
   let showWelcomeScreen = $state(false);
@@ -1354,9 +1363,19 @@
     return newPath;
   }
 
-  // Delete an entry - delegates to controller with sync support
+  // Delete an entry - shows confirmation dialog, then delegates to controller
   async function handleDeleteEntry(path: string) {
     if (!api) return;
+    pendingDeletePath = path;
+    showDeleteConfirm = true;
+  }
+
+  // Called when user confirms deletion in the dialog
+  async function confirmDeleteEntry() {
+    const path = pendingDeletePath;
+    showDeleteConfirm = false;
+    pendingDeletePath = null;
+    if (!api || !path) return;
     const parentPath = workspaceStore.getParentNodePath(path);
     await deleteEntryWithSync(api, path, currentEntry?.path ?? null, async () => {
       await refreshTree();
@@ -1365,6 +1384,12 @@
       }
       await runValidation();
     });
+  }
+
+  // Called when user cancels deletion
+  function cancelDeleteEntry() {
+    showDeleteConfirm = false;
+    pendingDeletePath = null;
   }
 
   // Run workspace validation (delegates to controller)
@@ -1857,6 +1882,22 @@
     }
   }}
 />
+
+<!-- Delete Confirmation Dialog -->
+<Dialog.Root bind:open={showDeleteConfirm} onOpenChange={(open) => { if (!open) cancelDeleteEntry(); }}>
+  <Dialog.Content showCloseButton={false} class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>Delete entry</Dialog.Title>
+      <Dialog.Description>
+        Are you sure you want to delete "{pendingDeleteName}"? This action cannot be undone.
+      </Dialog.Description>
+    </Dialog.Header>
+    <Dialog.Footer>
+      <Button variant="outline" onclick={cancelDeleteEntry}>Cancel</Button>
+      <Button variant="destructive" onclick={confirmDeleteEntry}>Delete</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>
 
 <!-- Toast Notifications -->
 <Toaster />

--- a/apps/web/src/controllers/entryController.ts
+++ b/apps/web/src/controllers/entryController.ts
@@ -265,6 +265,8 @@ export async function ensureDailyEntry(
 
 /**
  * Delete an entry.
+ *
+ * Callers are responsible for showing a confirmation dialog before calling this.
  */
 export async function deleteEntry(
   api: Api,
@@ -272,11 +274,6 @@ export async function deleteEntry(
   currentEntryPath: string | null,
   onSuccess?: () => Promise<void>
 ): Promise<boolean> {
-  const confirm = window.confirm(
-    `Are you sure you want to delete "${path.split('/').pop()?.replace('.md', '')}"?`
-  );
-  if (!confirm) return false;
-
   try {
     await api.deleteEntry(path);
 
@@ -537,11 +534,13 @@ export async function duplicateEntry(
  * Delete an entry with CRDT sync support.
  * Note: CRDT sync (soft delete) is now handled by Rust DeleteEntry command.
  *
+ * Callers are responsible for showing a confirmation dialog before calling this.
+ *
  * @param api - API instance
  * @param path - Path of the entry to delete
  * @param currentEntryPath - Path of the currently open entry (to clear if same)
  * @param onSuccess - Callback after successful deletion (e.g., refresh tree)
- * @returns True if deletion was confirmed and completed
+ * @returns True if deletion completed successfully
  */
 export async function deleteEntryWithSync(
   api: Api,
@@ -549,11 +548,6 @@ export async function deleteEntryWithSync(
   currentEntryPath: string | null,
   onSuccess?: () => Promise<void>
 ): Promise<boolean> {
-  const confirm = window.confirm(
-    `Are you sure you want to delete "${path.split('/').pop()?.replace('.md', '')}"?`
-  );
-  if (!confirm) return false;
-
   try {
     // Close body sync bridge for the deleted file
     closeBodySync(path);

--- a/crates/diaryx_core/src/cloud/README.md
+++ b/crates/diaryx_core/src/cloud/README.md
@@ -163,7 +163,20 @@ if result.success {
 4. **Upload**: Send local-only changes to remote
 5. **Download**: Fetch remote-only changes to local
 6. **Delete**: Remove files deleted from authoritative side
-7. **Update manifest**: Record new sync state
+7. **Manifest cleanup**: Remove stale entries for files deleted on both sides
+8. **Update manifest**: Record new sync state
+
+### Cross-Deletion Handling
+
+When a file is deleted on one side but changed on the other, the sync engine
+uses a "local wins" policy:
+
+- **Local delete + remote modify**: The local deletion takes precedence.
+  The file is deleted from remote and no download occurs.
+- **Local modify + remote delete**: The local modification takes precedence.
+  The file is uploaded to remote and no local delete occurs.
+- **Both sides deleted**: No file operations needed; only the manifest entry
+  is cleaned up.
 
 ## Progress Tracking
 

--- a/crates/diaryx_core/src/cloud/change.rs
+++ b/crates/diaryx_core/src/cloud/change.rs
@@ -154,6 +154,14 @@ pub enum SyncAction {
         /// Conflict information
         info: ConflictInfo,
     },
+    /// Clean up a manifest entry without any file operation.
+    ///
+    /// Used when both local and remote have deleted the same file -
+    /// neither side has it, so we just remove the stale manifest entry.
+    ManifestCleanup {
+        /// Path to remove from manifest
+        path: String,
+    },
 }
 
 impl SyncAction {
@@ -164,6 +172,7 @@ impl SyncAction {
             SyncAction::Download { path, .. } => path,
             SyncAction::Delete { path, .. } => path,
             SyncAction::Conflict { info } => &info.path,
+            SyncAction::ManifestCleanup { path } => path,
         }
     }
 
@@ -223,7 +232,13 @@ pub fn detect_conflicts(
 /// Compute sync actions from local and remote changes.
 ///
 /// This function determines what operations need to be performed to sync,
-/// handling conflicts appropriately.
+/// handling conflicts appropriately. It also handles cross-deletion scenarios:
+///
+/// - **Local delete + remote modify**: Local deletion takes precedence. The file
+///   is deleted from remote (no download).
+/// - **Local modify + remote delete**: Local modification takes precedence. The
+///   file is uploaded to remote (no local delete).
+/// - **Both sides deleted**: No action needed; manifest cleanup only.
 pub fn compute_sync_actions(
     local_changes: &[LocalChange],
     remote_changes: &[RemoteChange],
@@ -231,6 +246,23 @@ pub fn compute_sync_actions(
     let conflicts = detect_conflicts(local_changes, remote_changes);
     let conflict_paths: std::collections::HashSet<String> =
         conflicts.iter().map(|c| c.path.clone()).collect();
+
+    // Build sets for cross-deletion handling
+    let locally_deleted: std::collections::HashSet<String> = local_changes
+        .iter()
+        .filter_map(|c| match c {
+            LocalChange::Deleted { path } => Some(path.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let remotely_deleted: std::collections::HashSet<String> = remote_changes
+        .iter()
+        .filter_map(|c| match c {
+            RemoteChange::Deleted { path } => Some(path.clone()),
+            _ => None,
+        })
+        .collect();
 
     let mut actions = Vec::new();
 
@@ -247,18 +279,31 @@ pub fn compute_sync_actions(
 
         match change {
             LocalChange::Created { path, .. } | LocalChange::Modified { path, .. } => {
+                // Local create/modify always generates an upload.
+                // If the file was remotely deleted, we still upload to preserve
+                // local modifications (local wins).
                 actions.push(SyncAction::Upload { path: path.clone() });
             }
             LocalChange::Deleted { path } => {
-                actions.push(SyncAction::Delete {
-                    path: path.clone(),
-                    direction: SyncDirection::Upload, // Delete from remote
-                });
+                if remotely_deleted.contains(path) {
+                    // Both sides deleted - no action needed.
+                    // Emit a ManifestCleanup action so the manifest entry is removed.
+                    actions.push(SyncAction::ManifestCleanup {
+                        path: path.clone(),
+                    });
+                } else {
+                    // Normal local deletion or local delete + remote modify:
+                    // delete from remote (local deletion takes precedence).
+                    actions.push(SyncAction::Delete {
+                        path: path.clone(),
+                        direction: SyncDirection::Upload,
+                    });
+                }
             }
         }
     }
 
-    // Process remote changes (excluding conflicts)
+    // Process remote changes (excluding conflicts and cross-deletion paths)
     for change in remote_changes {
         if conflict_paths.contains(change.path()) {
             continue;
@@ -266,15 +311,34 @@ pub fn compute_sync_actions(
 
         match change {
             RemoteChange::Created { info } | RemoteChange::Modified { info, .. } => {
+                if locally_deleted.contains(&info.path) {
+                    // File was modified/created remotely but deleted locally.
+                    // Local deletion takes precedence - skip download.
+                    continue;
+                }
                 actions.push(SyncAction::Download {
                     path: info.path.clone(),
                     remote_info: info.clone(),
                 });
             }
             RemoteChange::Deleted { path } => {
+                if locally_deleted.contains(path) {
+                    // Both sides deleted - already handled above as ManifestCleanup.
+                    continue;
+                }
+                // Check if the file was locally modified/created - if so, skip
+                // the remote delete (local modification takes precedence).
+                let locally_changed = local_changes.iter().any(|c| match c {
+                    LocalChange::Created { path: p, .. }
+                    | LocalChange::Modified { path: p, .. } => p == path,
+                    _ => false,
+                });
+                if locally_changed {
+                    continue;
+                }
                 actions.push(SyncAction::Delete {
                     path: path.clone(),
-                    direction: SyncDirection::Download, // Delete from local
+                    direction: SyncDirection::Download,
                 });
             }
         }
@@ -381,5 +445,169 @@ mod tests {
         // Should only have conflict action, no upload/download for the conflicting file
         assert_eq!(actions.len(), 1);
         assert!(actions[0].is_conflict());
+    }
+
+    #[test]
+    fn test_local_delete_suppresses_remote_download() {
+        // File deleted locally but modified remotely - local delete should win,
+        // no download should be generated (this was causing resurrected files).
+        let local = vec![LocalChange::Deleted {
+            path: "deleted.md".to_string(),
+        }];
+        let remote = vec![RemoteChange::Modified {
+            info: make_remote_info("deleted.md"),
+            previous_version: Some("old-etag".to_string()),
+        }];
+
+        let actions = compute_sync_actions(&local, &remote);
+
+        // Should only have a delete-from-remote action, NO download
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter(|a| matches!(a, SyncAction::Delete { .. }))
+            .collect();
+        let downloads: Vec<_> = actions.iter().filter(|a| a.is_download()).collect();
+
+        assert_eq!(deletes.len(), 1, "Should have exactly one delete action");
+        assert_eq!(downloads.len(), 0, "Should NOT download a locally-deleted file");
+
+        if let SyncAction::Delete { direction, .. } = &deletes[0] {
+            assert_eq!(*direction, SyncDirection::Upload, "Should delete from remote");
+        }
+    }
+
+    #[test]
+    fn test_local_modify_suppresses_remote_delete() {
+        // File modified locally but deleted remotely - local modification should win,
+        // no local delete should be generated.
+        let local = vec![LocalChange::Modified {
+            path: "modified.md".to_string(),
+            content_hash: "new_hash".to_string(),
+            modified_at: 2000,
+            previous_hash: "old_hash".to_string(),
+        }];
+        let remote = vec![RemoteChange::Deleted {
+            path: "modified.md".to_string(),
+        }];
+
+        let actions = compute_sync_actions(&local, &remote);
+
+        // Should only have an upload action, NO local delete
+        let uploads: Vec<_> = actions.iter().filter(|a| a.is_upload()).collect();
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter(|a| matches!(a, SyncAction::Delete { .. }))
+            .collect();
+
+        assert_eq!(uploads.len(), 1, "Should upload the locally modified file");
+        assert_eq!(deletes.len(), 0, "Should NOT delete a locally-modified file");
+    }
+
+    #[test]
+    fn test_both_sides_deleted_produces_manifest_cleanup() {
+        // File deleted on both local and remote - should produce a ManifestCleanup,
+        // not conflicting delete actions that would fail.
+        let local = vec![LocalChange::Deleted {
+            path: "gone.md".to_string(),
+        }];
+        let remote = vec![RemoteChange::Deleted {
+            path: "gone.md".to_string(),
+        }];
+
+        let actions = compute_sync_actions(&local, &remote);
+
+        // Should only have a ManifestCleanup, no Delete actions
+        let cleanups: Vec<_> = actions
+            .iter()
+            .filter(|a| matches!(a, SyncAction::ManifestCleanup { .. }))
+            .collect();
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter(|a| matches!(a, SyncAction::Delete { .. }))
+            .collect();
+
+        assert_eq!(cleanups.len(), 1, "Should have one manifest cleanup");
+        assert_eq!(deletes.len(), 0, "Should have no delete actions");
+    }
+
+    #[test]
+    fn test_mixed_changes_with_cross_deletions() {
+        // Complex scenario: multiple files with various change combinations
+        let local = vec![
+            LocalChange::Created {
+                path: "new_local.md".to_string(),
+                content_hash: "h1".to_string(),
+                modified_at: 1000,
+            },
+            LocalChange::Deleted {
+                path: "deleted_both_sides.md".to_string(),
+            },
+            LocalChange::Deleted {
+                path: "deleted_local_modified_remote.md".to_string(),
+            },
+            LocalChange::Modified {
+                path: "modified_local_deleted_remote.md".to_string(),
+                content_hash: "new".to_string(),
+                modified_at: 2000,
+                previous_hash: "old".to_string(),
+            },
+        ];
+        let remote = vec![
+            RemoteChange::Created {
+                info: make_remote_info("new_remote.md"),
+            },
+            RemoteChange::Deleted {
+                path: "deleted_both_sides.md".to_string(),
+            },
+            RemoteChange::Modified {
+                info: make_remote_info("deleted_local_modified_remote.md"),
+                previous_version: None,
+            },
+            RemoteChange::Deleted {
+                path: "modified_local_deleted_remote.md".to_string(),
+            },
+        ];
+
+        let actions = compute_sync_actions(&local, &remote);
+
+        // Expected actions:
+        // 1. Upload "new_local.md" (new local file)
+        // 2. ManifestCleanup "deleted_both_sides.md" (both deleted)
+        // 3. Delete "deleted_local_modified_remote.md" from remote (local delete wins)
+        // 4. Upload "modified_local_deleted_remote.md" (local modify wins)
+        // 5. Download "new_remote.md" (new remote file)
+        let uploads: Vec<_> = actions
+            .iter()
+            .filter(|a| a.is_upload())
+            .map(|a| a.path())
+            .collect();
+        let downloads: Vec<_> = actions
+            .iter()
+            .filter(|a| a.is_download())
+            .map(|a| a.path())
+            .collect();
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter(|a| matches!(a, SyncAction::Delete { .. }))
+            .map(|a| a.path())
+            .collect();
+        let cleanups: Vec<_> = actions
+            .iter()
+            .filter(|a| matches!(a, SyncAction::ManifestCleanup { .. }))
+            .map(|a| a.path())
+            .collect();
+
+        assert_eq!(uploads.len(), 2);
+        assert!(uploads.contains(&"new_local.md"));
+        assert!(uploads.contains(&"modified_local_deleted_remote.md"));
+
+        assert_eq!(downloads.len(), 1);
+        assert!(downloads.contains(&"new_remote.md"));
+
+        assert_eq!(deletes.len(), 1);
+        assert!(deletes.contains(&"deleted_local_modified_remote.md"));
+
+        assert_eq!(cleanups.len(), 1);
+        assert!(cleanups.contains(&"deleted_both_sides.md"));
     }
 }

--- a/crates/diaryx_core/src/cloud/engine.rs
+++ b/crates/diaryx_core/src/cloud/engine.rs
@@ -371,6 +371,10 @@ impl<P: CloudSyncProvider> SyncEngine<P> {
                     self.manifest.remove_file(&path);
                     deleted += 1;
                 }
+                SyncAction::ManifestCleanup { path } => {
+                    // Both sides deleted this file - just clean up the manifest entry
+                    self.manifest.remove_file(&path);
+                }
                 SyncAction::Conflict { .. } => {
                     // Already handled above
                 }
@@ -639,6 +643,13 @@ impl<P: CloudSyncProvider> SyncEngine<P> {
                 self.manifest.remove_file(path);
                 deleted += 1;
                 completed += 1;
+            }
+        }
+
+        // Process manifest-only cleanups (both sides deleted)
+        for action in &actions {
+            if let SyncAction::ManifestCleanup { path } = action {
+                self.manifest.remove_file(path);
             }
         }
 


### PR DESCRIPTION
Two bugs fixed:

1. Cloud sync would resurrect locally-deleted files when the remote copy
   had a different etag/timestamp. compute_sync_actions() generated both
   a Download and Delete action for the same path. Since downloads execute
   before deletes, the file was re-created locally. Fixed by suppressing
   the Download when the file was locally deleted (local deletion wins)
   and suppressing remote Delete when the file was locally modified.
   Added ManifestCleanup action for the both-sides-deleted case.

2. Deletion confirmation used window.confirm() which may not block
   properly in Tauri's webview, causing the file to be deleted before
   the user responds. Replaced with a proper async Dialog component
   that waits for explicit user confirmation before proceeding.

https://claude.ai/code/session_01XN3fd3pX44g4SiZpxgNMdL