### PR TITLE
Use HTTPS instead of SSH for fig git dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "fig"
 version = "0.0.0"
-source = "git+ssh://git@github.com/adammharris/fig.git?rev=2b6079d683f5f5678f15401cde54404a683bc518#2b6079d683f5f5678f15401cde54404a683bc518"
+source = "git+https://github.com/adammharris/fig.git?rev=2b6079d683f5f5678f15401cde54404a683bc518#2b6079d683f5f5678f15401cde54404a683bc518"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ license-file = "LICENSE.md"
 [workspace.dependencies]
 # Shared dependencies across workspace
 # fig: Zig-backed YAML parser/editor (replaces serde_yaml_ng in diaryx_core).
-fig = { git = "ssh://git@github.com/adammharris/fig.git", rev = "2b6079d683f5f5678f15401cde54404a683bc518" }
+fig = { git = "https://github.com/adammharris/fig.git", rev = "2b6079d683f5f5678f15401cde54404a683bc518" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10"


### PR DESCRIPTION
The fig dependency was specified with an ssh:// URL, which requires SSH
authentication. CI runners have no SSH key for adammharris/fig, so the
build failed with 'no authentication methods succeeded'. fig is a public
repo, so HTTPS needs no credentials and works in both CI and local
checkouts.