### PR TITLE
fix(ci) bake correct iOS xcode-script via cargo tauri

### DIFF
--- a/.github/workflows/appstore-release.yml
+++ b/.github/workflows/appstore-release.yml
@@ -46,6 +46,19 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'ios' && 'aarch64-apple-ios' || 'aarch64-apple-darwin,x86_64-apple-darwin' }}
 
+      # iOS only: `cargo xtask publish-ios` drives the build with `cargo tauri`
+      # so the generated Xcode "Build Rust Code" phase re-invokes the CLI as
+      # `cargo tauri ios xcode-script` (cwd-independent). The npm-pinned
+      # `.bin/tauri` would bake an unresolvable `node tauri` instead. Pin to the
+      # same version as @tauri-apps/cli in apps/web/package.json.
+      - name: Set up cargo-binstall
+        if: matrix.platform == 'ios'
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install Tauri CLI
+        if: matrix.platform == 'ios'
+        run: cargo binstall -y tauri-cli@2.10.1
+
       # Required by diaryx_core -> fig, whose build.rs shells out to `zig build`.
       - name: Install Zig
         uses: ./.github/actions/setup-zig

--- a/xtask/src/publish_ios.rs
+++ b/xtask/src/publish_ios.rs
@@ -1,5 +1,27 @@
-use crate::util::{require_env, run_checked, tauri_command, workspace_root};
+use crate::util::{require_env, run_checked, workspace_root};
 use std::process::Command;
+
+/// Build a `cargo tauri` command for the iOS build.
+///
+/// iOS must use `cargo tauri` rather than the npm-pinned `.bin/tauri` (used
+/// elsewhere via `tauri_command`). `tauri ios init` bakes the CLI invocation
+/// into the generated Xcode "Build Rust Code" phase as
+/// `<tauri-binary> ios xcode-script ...`. Tauri derives that command from
+/// `std::env::args_os()`: when the npm CLI is spawned directly (not through a
+/// package manager), `argv[0]` is `node` and no `npm_execpath`/`PNPM_*` env is
+/// set, so Tauri bakes a bare `node tauri ...`. Xcode runs that phase from
+/// `gen/apple`, so node resolves `tauri` to `gen/apple/tauri` and fails with
+/// "Cannot find module '.../gen/apple/tauri'". The package-manager code paths
+/// can't help here either: this repo's package.json lives in apps/web, which is
+/// not an ancestor of gen/apple, so a baked `bun tauri`/`npm run tauri` would
+/// not resolve from the build phase's working directory. `cargo tauri` bakes
+/// `cargo tauri ios xcode-script ...`, which is cwd-independent (it only needs
+/// `cargo`/`cargo-tauri` on PATH, which Xcode inherits from the CI job).
+fn cargo_tauri() -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("tauri");
+    cmd
+}
 
 const USAGE: &str = "Usage: cargo xtask publish-ios\n\n\
 Builds the iOS App Store export (Tauri `apple` feature) and uploads the IPA to\n\
@@ -43,17 +65,17 @@ pub fn run(args: &[String]) -> Result<(), String> {
     // when missing; skip if a previous `tauri ios init` already created it.
     let gen_apple = tauri_dir.join("src-tauri/gen/apple");
     if !gen_apple.exists() {
-        println!("==> Initializing iOS Xcode project (tauri ios init)...");
-        let mut init = tauri_command();
+        println!("==> Initializing iOS Xcode project (cargo tauri ios init)...");
+        let mut init = cargo_tauri();
         init.current_dir(&tauri_dir).args(["ios", "init"]);
         if let Some(team) = &development_team {
             init.env("APPLE_DEVELOPMENT_TEAM", team);
         }
-        run_checked(&mut init, "tauri ios init")?;
+        run_checked(&mut init, "cargo tauri ios init")?;
     }
 
     println!("==> Building iOS app...");
-    let mut build = tauri_command();
+    let mut build = cargo_tauri();
     build
         .current_dir(&tauri_dir)
         .env("APPLE_API_KEY", &api_key)
@@ -71,7 +93,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
     if let Some(team) = &development_team {
         build.env("APPLE_DEVELOPMENT_TEAM", team);
     }
-    run_checked(&mut build, "tauri ios build")?;
+    run_checked(&mut build, "cargo tauri ios build")?;
 
     let ipa_dir = root.join("apps/tauri/src-tauri/gen/apple/build");
     let ipa = find_ipa(&ipa_dir)?;


### PR DESCRIPTION
The iOS App Store publish failed with:

  Error: Cannot find module '.../apps/tauri/src-tauri/gen/apple/tauri'

`tauri ios init` bakes the CLI invocation into the generated Xcode
"Build Rust Code" phase as `<tauri-binary> ios xcode-script ...`,
deriving it from std::env::args_os(). When the npm-pinned `.bin/tauri`
is spawned directly (not via a package manager), argv[0] is `node` and
no npm_execpath/PNPM_* env is set, so Tauri bakes a bare `node tauri`.
Xcode runs that phase from gen/apple, so node resolves `tauri` to
gen/apple/tauri and fails. The package-manager paths can't help either:
this repo's package.json lives in apps/web, which is not an ancestor of
gen/apple, so a baked `bun tauri`/`npm run tauri` wouldn't resolve from
the build phase's cwd.

Use `cargo tauri` for the iOS init+build instead, which bakes
`cargo tauri ios xcode-script ...` (cwd-independent). Install cargo-tauri
on the iOS leg, pinned to the same 2.10.1 as @tauri-apps/cli. macOS keeps
using the npm CLI (its desktop build has no xcode-script phase).

https://claude.ai/code/session_01TP95NUxAXeEFwn8QzSBByw